### PR TITLE
[scripts] Add cluster utils script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ If you are already running a validator on AWS EKS, follow this part to migrate. 
 ### Deploy the new cluster in fullnode mode
 - Make sure `mode: fullnode` in your inventory file.
 - Follow the [Deploy Saga Pegasus](#deploy-saga-pegasus) instructions
-- Verify that the validator is spinning up new chains once SPC is in sync `kubectl get pods -A | grep chainlet`
-- Make sure the chains are in sync: `scripts/chainlets-status.sh [--kubeconfig <kubeconfig_file>]`. It will print a success or failure message at the end.
+- Make sure the chains are in sync: `scripts/cluster.sh chainlets-status [--kubeconfig <kubeconfig_file>]`. It will print a success or failure message at the end.
 
 ### Scale down the old cluster
 **After making sure the new cluster is in sync**
@@ -75,7 +74,20 @@ If you are already running a validator on AWS EKS, follow this part to migrate. 
 - In the inventory set `mode: validator`
 - Make sure you have the `validator_mnemonic` correctly set
 - Redeploy ([Deploy](#deploy))
-- Restart the controller: `kubectl delete pod -l app=controller -n sagasrv-controller`
-- Redeploy every chainlet deleting the deployment and having the controller redeploy it as validator: `kubectl get pods -A | awk '/chainlet/{print "kubectl delete deployment chainlet -n " $1}'` and then execute the commands in the output.
+- Restart the controller: `scripts/cluster.sh restart-controller`
+- Redeploy every chainlet deleting the deployment and having the controller redeploy it as validator: `scripts/cluster.sh redeploy-all-chainlets` and then execute the commands in the output.
 
-Now you should be able to see all the chainlets restarting: `kubectl get pods -A | grep chainlet`. Check the log of any of those to make sure they are participating 
+Now you should be able to see all the chainlets restarting: `kubectl get pods -A | grep chainlet`. Check the status with `scripts/cluster.sh chainlets-status` making sure all of them are restarting and getting in sync.
+
+## Utils
+### cluster.sh
+Collection of util commands to interact with the cluster. It supports the common operations:
+- scale-down-controller           Scale down the controller deployment"
+- scale-up-controller             Scale up the controller deployment"
+- restart-controller              Restart controller pod"
+- restart-chainlet <identifier>   Restart chainlet pods by namespace or chain_id"
+- redeploy-chainlet <identifier>  Redeploy chainlet deployment by namespace or chain_id"
+- redeploy-all-chainlets          Redeploy all chainlet deployments in saga-* namespaces"
+- chainlets-status                Show status of all chainlets"
+
+Optionally, pass `--kubeconfig <your_kubeconfig>` to use a different context, than the current. Use `scripts/cluster.sh --help` for usage.

--- a/scripts/chainlets-status.sh
+++ b/scripts/chainlets-status.sh
@@ -1,26 +1,7 @@
 #!/bin/bash
 
-# ANSI color codes
-GREEN='\033[0;32m'
-RED='\033[0;31m'
-YELLOW='\033[0;33m'
-NC='\033[0m' # No Color
-
-log() {
-    echo -e "$1"
-}
-
-success() {
-    echo -e "${GREEN}$1${NC}"
-}
-
-error() {
-    echo -e "${RED}$1${NC}"
-}
-
-warning() {
-    echo -e "${YELLOW}$1${NC}"
-}
+# Source shared logging functions
+source "$(dirname "$0")/shared/log.sh"
 
 print_usage() {
     log "Usage: $0 [OPTIONS]"
@@ -140,11 +121,11 @@ for file in "$tmp_dir"/*.txt; do
                 ;;
             "true")
                 ((catching_up++))
-                catching_up_chains+=("$chainlet")
+                catching_up_chains+=("saga-${chainlet//_/-}")
                 ;;
             *)
                 ((not_running++))
-                not_running_chains+=("$chainlet")
+                not_running_chains+=("saga-${chainlet//_/-}")
                 ;;
         esac
     fi

--- a/scripts/cluster.sh
+++ b/scripts/cluster.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+# Source shared logging functions
+source "$(dirname "$0")/shared/log.sh"
+
+print_usage() {
+    log "Usage: $0 [OPTIONS] COMMAND"
+    log ""
+    log "Execute operations on the Saga cluster"
+    log ""
+    log "OPTIONS:"
+    log "  --kubeconfig PATH    Path to kubeconfig file (optional)"
+    log "  -h, --help          Show this help message"
+    log ""
+    log "COMMANDS:"
+    log "  scale-down-controller          Scale down the controller deployment"
+    log "  scale-up-controller           Scale up the controller deployment"
+    log "  restart-chainlet <identifier>  Restart chainlet pods by namespace or chain_id"
+    log "  redeploy-chainlet <identifier> Redeploy chainlet deployment by namespace or chain_id"
+    log ""
+    log "EXAMPLES:"
+    log "  $0 scale-down-controller                        # Scale down using default kubeconfig"
+    log "  $0 --kubeconfig ~/.kube/config scale-up-controller   # Scale up using specific kubeconfig"
+    log "  $0 restart-chainlet saga-my-chain              # Restart using full namespace"
+    log "  $0 restart-chainlet my_chain_id                # Restart using chain_id (converts to saga-my-chain-id)"
+    log "  $0 redeploy-chainlet saga-my-chain             # Redeploy using full namespace"
+    log "  $0 redeploy-chainlet my_chain_id               # Redeploy using chain_id"
+}
+
+log_and_execute_cmd() {
+    log "$*"
+    eval "$*"
+}
+
+# Shared function to get namespace from identifier
+get_namespace() {
+    local identifier="$1"
+    if [[ "$identifier" == saga-* ]]; then
+        # Already a namespace format
+        echo "$identifier"
+    else
+        # Convert chain_id to namespace format (replace _ with -, add saga- prefix)
+        echo "saga-${identifier//_/-}"
+    fi
+}
+
+# Parse command line arguments
+KUBECONFIG_FILE=""
+COMMAND=""
+CHAINLET_IDENTIFIER=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --kubeconfig)
+            KUBECONFIG_FILE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        scale-down-controller|scale-up-controller)
+            COMMAND="$1"
+            shift
+            ;;
+        restart-chainlet|redeploy-chainlet)
+            COMMAND="$1"
+            if [[ $# -lt 2 ]]; then
+                error "$1 command requires an identifier (namespace or chain_id)"
+                echo ""
+                print_usage
+                exit 1
+            fi
+            CHAINLET_IDENTIFIER="$2"
+            shift 2
+            ;;
+        *)
+            error "Unknown option/command: $1"
+            echo ""
+            print_usage
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$COMMAND" ]; then
+    error "No command specified"
+    echo ""
+    print_usage
+    exit 1
+fi
+
+# Set kubectl command with optional kubeconfig
+if [ -n "$KUBECONFIG_FILE" ]; then
+    if [ ! -f "$KUBECONFIG_FILE" ]; then
+        error "Kubeconfig file not found: $KUBECONFIG_FILE"
+        exit 1
+    fi
+    KUBECTL="kubectl --kubeconfig=$KUBECONFIG_FILE"
+    log "Using kubeconfig: $KUBECONFIG_FILE"
+else
+    KUBECTL="kubectl"
+    log "Using current context: $($KUBECTL config current-context)"
+fi
+
+# Execute commands
+case "$COMMAND" in
+    scale-down-controller)
+        log "Scaling down controller..."
+        log_and_execute_cmd $KUBECTL scale deployment/controller -n sagasrv-controller --replicas=0
+        if [ $? -eq 0 ]; then
+            success "Controller scaled down successfully. Don't forget to $0 scale-up-controller"
+        else
+            error "Failed to scale down controller"
+            exit 1
+        fi
+        ;;
+    scale-up-controller)
+        log "Scaling up controller..."
+        log_and_execute_cmd $KUBECTL scale deployment/controller -n sagasrv-controller --replicas=1
+        if [ $? -eq 0 ]; then
+            success "Controller scaled up successfully"
+        else
+            error "Failed to scale up controller"
+            exit 1
+        fi
+        ;;
+    restart-chainlet)
+        NAMESPACE=$(get_namespace "$CHAINLET_IDENTIFIER")
+        log "Restarting chainlet in namespace: $NAMESPACE"
+
+        log_and_execute_cmd $KUBECTL delete pod -n "$NAMESPACE" -l app=chainlet
+        
+        if [ $? -eq 0 ]; then
+            success "Chainlet pods in namespace '$NAMESPACE' restarted successfully"
+            log "New pods will be created automatically by the deployment"
+        else
+            error "Failed to restart chainlet pods in namespace '$NAMESPACE'"
+            exit 1
+        fi
+        ;;
+    redeploy-chainlet)
+        NAMESPACE=$(get_namespace "$CHAINLET_IDENTIFIER")
+        log "Redeploying chainlet in namespace: $NAMESPACE"
+
+        log_and_execute_cmd $KUBECTL delete deployment chainlet -n "$NAMESPACE"
+        
+        if [ $? -eq 0 ]; then
+            success "Chainlet deployment in namespace '$NAMESPACE' deleted successfully"
+            log "New deployment will be created automatically by the controller"
+        else
+            error "Failed to delete chainlet deployment in namespace '$NAMESPACE'"
+            exit 1
+        fi
+        ;;
+esac

--- a/scripts/cmd/chainlets-status.sh
+++ b/scripts/cmd/chainlets-status.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Source shared logging functions
-source "$(dirname "$0")/shared/log.sh"
+source "$(dirname "$0")/../shared/log.sh"
 
 print_usage() {
     log "Usage: $0 [OPTIONS]"
@@ -55,10 +55,10 @@ if [ -n "$KUBECONFIG_FILE" ]; then
         exit 1
     fi
     KUBECTL="kubectl --kubeconfig=$KUBECONFIG_FILE"
-    log "Using kubeconfig: $KUBECONFIG_FILE"
+    # log "Using kubeconfig: $KUBECONFIG_FILE"
 else
     KUBECTL="kubectl"
-    log "Using current context: $($KUBECTL config current-context)"
+    # log "Using current context: $($KUBECTL config current-context)"
 fi
 
 log ""

--- a/scripts/shared/io.sh
+++ b/scripts/shared/io.sh
@@ -1,0 +1,13 @@
+
+# Function to ask for confirmation
+confirm_action() {
+    local message="$1"
+    log "$message"
+    read -p "Continue? (Y/n): " -r
+    echo
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+        log "Operation cancelled"
+        return 1
+    fi
+    return 0
+}

--- a/scripts/shared/log.sh
+++ b/scripts/shared/log.sh
@@ -1,0 +1,21 @@
+# ANSI color codes
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+log() {
+    echo -e "$1"
+}
+
+success() {
+    echo -e "${GREEN}$1${NC}"
+}
+
+error() {
+    echo -e "${RED}$1${NC}"
+}
+
+warning() {
+    echo -e "${YELLOW}$1${NC}"
+}

--- a/scripts/shared/log.sh
+++ b/scripts/shared/log.sh
@@ -2,6 +2,7 @@
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 YELLOW='\033[0;33m'
+BOLD='\033[1m'
 NC='\033[0m' # No Color
 
 log() {


### PR DESCRIPTION
Adding `scripts/cluster.sh` a cluster cli to abstract kubectl commands. Now supporting:
- scale-down-controller
- scale-up-controller
- restart-controller
- restart-chainlet <identifier> (identifier can seamlessly be the namespace or the chainid)
- redeploy-chainlet <identifier>
- redeploy-all-chainlets
- chainlets-status

There are few advantages:
- Safer: we perform all possible checks around some command. E.g.: redeploy chainlet makes sure the controller is running
- Easier to use: human readable commands vs tricky kubectl pipes
- Easier to communicate: simple commands to share with partners
Documented: the readme and --help will tell user all they need to know