### PR TITLE
[cluster.sh] Add bash autocomplete and log command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Collection of util commands to interact with the cluster. It supports the common
 - redeploy-chainlet <identifier>  Redeploy chainlet deployment by namespace or chain_id"
 - redeploy-all-chainlets          Redeploy all chainlet deployments in saga-* namespaces"
 - chainlets-status                Show status of all chainlets"
-- logs <identifier>               Chainlet logs by 
+- logs <identifier>               Follow chainlet logs by namespace or chain_id
+- chainlet-status <identifier>    Show sync status for a specific chainlet 
 - install-completion              Install bash completion for cluster.sh
 
 

--- a/README.md
+++ b/README.md
@@ -89,5 +89,13 @@ Collection of util commands to interact with the cluster. It supports the common
 - redeploy-chainlet <identifier>  Redeploy chainlet deployment by namespace or chain_id"
 - redeploy-all-chainlets          Redeploy all chainlet deployments in saga-* namespaces"
 - chainlets-status                Show status of all chainlets"
+- logs <identifier>               Chainlet logs by 
+- install-completion              Install bash completion for cluster.sh
+
 
 Optionally, pass `--kubeconfig <your_kubeconfig>` to use a different context, than the current. Use `scripts/cluster.sh --help` for usage.
+
+**Make it faster**
+- Add alias `c=<your_path>/scripts/cluster.sh` to the file loaded on start of the terminal (e.g. `~/.bashrc`, `~/.zshrc`)
+- Run `c install-completion`
+- Enjoy autocomplete of commands, options, namespaces and chainids.

--- a/scripts/config/cluster-completion.bash
+++ b/scripts/config/cluster-completion.bash
@@ -8,7 +8,7 @@ _cluster_completion() {
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     # Available commands
-    commands="scale-down-controller scale-up-controller restart-controller restart-chainlet redeploy-chainlet redeploy-all-chainlets logs chainlets-status install-completion"
+    commands="scale-down-controller scale-up-controller restart-controller restart-chainlet redeploy-chainlet redeploy-all-chainlets logs chainlet-status chainlets-status install-completion"
     
     # Available options
     opts="--kubeconfig -h --help"
@@ -22,7 +22,7 @@ _cluster_completion() {
 
     # Handle command-specific completions
     case "${prev}" in
-        restart-chainlet|redeploy-chainlet|logs)
+        restart-chainlet|redeploy-chainlet|logs|chainlet-status)
             # For chainlet commands, complete with both namespaces and chainids
             if command -v kubectl >/dev/null 2>&1; then
                 # Get saga-* namespaces (full namespace names)

--- a/scripts/config/cluster-completion.bash
+++ b/scripts/config/cluster-completion.bash
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Bash completion for cluster.sh script
+
+_cluster_completion() {
+    local cur prev opts commands
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    # Available commands
+    commands="scale-down-controller scale-up-controller restart-controller restart-chainlet redeploy-chainlet redeploy-all-chainlets logs chainlets-status install-completion"
+    
+    # Available options
+    opts="--kubeconfig -h --help"
+
+    # Handle --kubeconfig argument completion
+    if [[ ${prev} == "--kubeconfig" ]]; then
+        # Complete with files (kubeconfig files)
+        COMPREPLY=($(compgen -f "${cur}"))
+        return 0
+    fi
+
+    # Handle command-specific completions
+    case "${prev}" in
+        restart-chainlet|redeploy-chainlet|logs)
+            # For chainlet commands, complete with both namespaces and chainids
+            if command -v kubectl >/dev/null 2>&1; then
+                # Get saga-* namespaces (full namespace names)
+                local namespaces=$(kubectl get namespaces -o name 2>/dev/null | grep "namespace/saga-" | cut -d/ -f2 2>/dev/null)
+                
+                # Convert namespaces to chainids (remove saga- prefix and convert - to _)
+                local chainids=""
+                for ns in $namespaces; do
+                    if [[ $ns == saga-* ]]; then
+                        # Remove saga- prefix and convert - to _
+                        local chainid="${ns#saga-}"
+                        chainid="${chainid//-/_}"
+                        chainids="$chainids $chainid"
+                    fi
+                done
+                
+                # Combine both namespace and chainid completions
+                local all_completions="$namespaces $chainids"
+                COMPREPLY=($(compgen -W "${all_completions}" -- "${cur}"))
+            fi
+            return 0
+            ;;
+    esac
+
+    # If we're completing the first argument (after script name)
+    if [[ ${COMP_CWORD} -eq 1 ]]; then
+        # Complete with options and commands
+        COMPREPLY=($(compgen -W "${opts} ${commands}" -- "${cur}"))
+        return 0
+    fi
+
+    # If we have an option flag, complete with commands
+    local has_command=false
+    for word in "${COMP_WORDS[@]:1}"; do
+        if [[ " ${commands} " =~ " ${word} " ]]; then
+            has_command=true
+            break
+        fi
+    done
+
+    if [[ ${has_command} == false ]]; then
+        # No command found yet, suggest commands
+        COMPREPLY=($(compgen -W "${commands}" -- "${cur}"))
+    fi
+
+    return 0
+}
+
+# Register the completion function
+complete -F _cluster_completion cluster.sh
+
+# Also register for common ways the script might be called
+complete -F _cluster_completion ./cluster.sh
+complete -F _cluster_completion scripts/cluster.sh
+complete -F _cluster_completion ./scripts/cluster.sh


### PR DESCRIPTION
This adds bash autocomplete for:
- commands (e.g.: restart-controller)
- options (e.g.: --kubeconfig)
- chain identifier (namespaces and chain-ids)

Command to follow the logs of a chianlet given the identifier.