### PR TITLE
Update migration instructions and spc_peers

### DIFF
--- a/ansible/group_vars/network/mainnet.yml
+++ b/ansible/group_vars/network/mainnet.yml
@@ -1,7 +1,6 @@
 # Chains config (spc and chainlets)
 spc_chain_id: spc-1
 spc_volume_size: 100Gi
-spc_peers: "1b10864a39dab62a73f4e669951138398eae4e76@spc.spsrv1.sagarpc.io:26656,fd262927112b698f848abf737d0a6370d1b09db3@spc.spsrv2.sagarpc.io:26656"
 s3_bucket: s3://mainnet-prod
 quorum_count: 4
 validator_addresses: saga1pdf6slnws5hqeg0wz5t4snrfzyx7wg7fra84q3 saga1954vr9dlykxxtmazesz3llntmdz7pn0ep07x6v saga1dque6vr4lzlkl0uqn6v6tdxys5g466jphah7d4 saga18u6dnjzd2gzh5fgprtwvx9adfwwn99qc6tagnh

--- a/ansible/group_vars/network/staging.yml
+++ b/ansible/group_vars/network/staging.yml
@@ -1,7 +1,6 @@
 # Chains config (spc and chainlets)
 spc_chain_id: spc-staging-1
 spc_volume_size: 50Gi
-spc_peers: "4f51f1595f349ddb6ee925fef2e7ba469cb5d96a@spc.staging1.sagarpc.io:26656,0c54e7c87139fd1d4f99e8029c1987e360bbd2d6@spc.staging-srv.sagarpc.io:26656"
 s3_bucket: s3://testnet-staging
 quorum_count: 2
 validator_addresses: saga10h0ngnu5cz0e2v5k6pdz2l5xhl3edhnlqvrdd2 saga1uhuu689scjs9jpcyuapzdvxdxyh3rz46n29cdn

--- a/ansible/roles/controller/templates/config/controller-config.yml.j2
+++ b/ansible/roles/controller/templates/config/controller-config.yml.j2
@@ -43,7 +43,7 @@ deployment:
         number: 8546
         host_suffix: ""
     env:
-      validator_mnemonic: "{{ validator_mnemonic | default('void') }}"
+      validator_mnemonic: "{% if validator_provider == 1 %}{{ validator_mnemonic }}{% else %}void{% endif %}"
       s3bucket: "{{ s3_bucket }}/chainlets/gentx"
       validator_provider: "{{ validator_provider }}"
       moniker: "{{ moniker }}"


### PR DESCRIPTION
A few changes for the onpremise migration:
- Add instructions to the readme (SPC need to be wiped)
- Do not pass mnemonic if fullnode mode to be safe
- Remove spc_peers, now state sync is offered by validators too. So, we can avoid bottlenecks.