### PR TITLE
[ethproxy] Add dedicated fullnodes

### DIFF
--- a/ansible/roles/ethproxy/templates/ethproxy-config.yml.j2
+++ b/ansible/roles/ethproxy/templates/ethproxy-config.yml.j2
@@ -3,7 +3,7 @@ node_rpc: "{{ ethproxy_config.node_rpc }}"
 node_json_rpc: "{{ ethproxy_config.node_json_rpc }}"
 chain_id: "{{ ethproxy_config.chain_id }}"
 account_address_prefix: "saga"
-json_rpc_request_timeout: "10s"
+json_rpc_request_timeout: "30s"
 server:
   json_rpc:
     address: "0.0.0.0:8545"

--- a/ansible/roles/ethproxy/templates/ethproxy-deploy.yml.j2
+++ b/ansible/roles/ethproxy/templates/ethproxy-deploy.yml.j2
@@ -27,7 +27,7 @@ metadata:
   name: ethproxy
   namespace: {{ ethproxy_config.namespace }}
 spec:
-  replicas: {{ ethproxy_config.ethproxy_replicas | default(ethproxy_replicas) }}
+  replicas: {{ ethproxy_config.replicas | default(ethproxy_replicas) }}
   selector:
     matchLabels:
       app: ethproxy
@@ -116,3 +116,230 @@ spec:
                 port:
                   number: 8545
 {% endfor %}
+{% if ethproxy_config.fullnodes.enabled %}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chainlet-env
+  namespace: {{ ethproxy_config.namespace }}
+data:
+  CHAIN_ID: {{ ethproxy_config.chain_id }}
+  GENESIS_URL: "{{ ethproxy_config.fullnodes.genesis_url }}"
+  PEERS: "{{ ethproxy_config.fullnodes.peers }}"
+  DENOM: "{{ ethproxy_config.fullnodes.denom }}"
+  LOG_LEVEL: "info"
+  SYNC_RPC: "{{ ethproxy_config.fullnodes.sync_rpc_urls | join(',') }}"
+  MONIKER: "{{ moniker }}"
+  PRUNING: "{{ ethproxy_config.fullnodes.pruning_strategy }}"
+  OPTS: "{{ ethproxy_config.fullnodes.opts | default('') }}"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: chainlet-rw
+  namespace: {{ ethproxy_config.namespace }}
+spec:
+  replicas: {{ ethproxy_config.fullnodes.replicas_rw }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: chainlet-rw
+  template:
+    metadata:
+      labels:
+        app: chainlet-rw
+        chainId: "{{ ethproxy_config.chain_id }}-rw"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "26660"
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Always
+      containers:
+        - image: "sagaxyz/sagaos:{{ ethproxy_config.fullnodes.version }}"
+          name: chainlet
+          command: ["bash", "/root/start-fullnode.sh"]
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: chainlet-env
+          ports:
+            - containerPort: 26657
+            - containerPort: 26656
+            - containerPort: 9090
+            - containerPort: 1317
+            - containerPort: 8545
+            - containerPort: 8546
+            - containerPort: 26660
+          readinessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - sagaosd status | jq -r '(.SyncInfo // .sync_info) | .catching_up' | grep false
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 4
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "1"
+            limits:
+              memory: "4Gi"
+              cpu: "2"
+          volumeMounts:
+            - name: data-volume
+              mountPath: "/root/.sagaosd/data"
+            - name: config-volume
+              mountPath: "/root/.sagaosd/config"
+      volumes:
+        - name: config-volume
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: data-volume
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 20Gi
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: chainlet-ro
+  namespace: {{ ethproxy_config.namespace }}
+spec:
+  replicas: {{ ethproxy_config.fullnodes.replicas_ro }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: chainlet-ro
+  template:
+    metadata:
+      labels:
+        app: chainlet-ro
+        chainId: "{{ ethproxy_config.chain_id }}-ro"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "26660"
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: Always
+      containers:
+        - image: "sagaxyz/sagaos:{{ ethproxy_config.fullnodes.version }}"
+          name: chainlet
+          command: ["bash", "/root/start-fullnode.sh"]
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: chainlet-env
+          ports:
+            - containerPort: 26657
+            - containerPort: 26656
+            - containerPort: 9090
+            - containerPort: 1317
+            - containerPort: 8545
+            - containerPort: 8546
+            - containerPort: 26660
+          readinessProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -c
+                - sagaosd status | jq -r '(.SyncInfo // .sync_info) | .catching_up' | grep false
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 4
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "1"
+            limits:
+              memory: "4Gi"
+              cpu: "2"
+          volumeMounts:
+            - name: data-volume
+              mountPath: "/root/.sagaosd/data"
+            - name: config-volume
+              mountPath: "/root/.sagaosd/config"
+      volumes:
+        - name: config-volume
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: data-volume
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 20Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "chainlet-ro"
+  namespace: {{ ethproxy_config.namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    app: "chainlet-ro"
+  ports:
+    - name: tendermintrpc
+      port: 26657
+      targetPort: 26657
+    - name: tendermintrpc-p2p
+      port: 26656
+      targetPort: 26656
+    - name: cosmosgrpc
+      port: 9090
+      targetPort: 9090
+    - name: tendermintlcd
+      port: 1317
+      targetPort: 1317
+    - name: evmjsonrpc
+      port: 8545
+      targetPort: 8545
+    - name: evmws
+      port: 8546
+      targetPort: 8546
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "chainlet-rw"
+  namespace: {{ ethproxy_config.namespace }}
+spec:
+  type: ClusterIP
+  selector:
+    app: "chainlet-rw"
+  ports:
+    - name: tendermintrpc
+      port: 26657
+      targetPort: 26657
+    - name: tendermintrpc-p2p
+      port: 26656
+      targetPort: 26656
+    - name: cosmosgrpc
+      port: 9090
+      targetPort: 9090
+    - name: tendermintlcd
+      port: 1317
+      targetPort: 1317
+    - name: evmjsonrpc
+      port: 8545
+      targetPort: 8545
+    - name: evmws
+      port: 8546
+      targetPort: 8546
+{% endif %}

--- a/ansible/roles/ingress-nginx/templates/ingress-nginx-values.yml.j2
+++ b/ansible/roles/ingress-nginx/templates/ingress-nginx-values.yml.j2
@@ -12,6 +12,8 @@ controller:
     enabled: {{ ingress_nginx_metrics_enabled | lower }}
     serviceMonitor:
       enabled: {{ ingress_nginx_metrics_service_monitor_enabled | lower }}
+      additionalLabels:
+        release: kube-prometheus-stack
 
   service:
     enabled: false

--- a/ansible/roles/metrics/templates/alertmanager-config.yml.j2
+++ b/ansible/roles/metrics/templates/alertmanager-config.yml.j2
@@ -45,7 +45,6 @@ receivers:
 {% if channel.type == 'slack' %}
     slack_configs:
       - api_url: '{{ channel.api_url }}'
-        channel: '{{ channel.channel }}'
         title: '{{ channel.title }}'
         text: '{{ channel.text }}'
         send_resolved: true
@@ -78,7 +77,6 @@ receivers:
 {% if channel.type == 'slack' %}
     slack_configs:
       - api_url: '{{ channel.api_url }}'
-        channel: '{{ channel.channel }}'
         title: '{{ channel.title }}'
         text: '{{ channel.text }}'
         send_resolved: true
@@ -107,7 +105,6 @@ receivers:
 {% if channel.type == 'slack' %}
     slack_configs:
       - api_url: '{{ channel.api_url }}'
-        channel: '{{ channel.channel }}'
         title: '{{ channel.title }}'
         text: '{{ channel.text }}'
         send_resolved: true

--- a/ansible/roles/ssc/templates/ssc-deploy.yml.j2
+++ b/ansible/roles/ssc/templates/ssc-deploy.yml.j2
@@ -43,9 +43,6 @@ spec:
     metadata:
       labels:
         app: ssc
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "26660"
     spec:
       containers:
         - name: ssc


### PR DESCRIPTION
Having ethproxy using the same node used by the indexer doesn't scale. This change adds dedicated fullnodes (optional) to the ethproxy configuration.

Small fixes:
- Remove slack channel from alertmanager config (not needed)
- Remove prometheus target from ssc fullnode