### PR TITLE
[alertmaneger] Add external url

### DIFF
--- a/ansible/group_vars/network/mainnet.yml
+++ b/ansible/group_vars/network/mainnet.yml
@@ -28,7 +28,7 @@ ssc_genesis_url: "https://raw.githubusercontent.com/sagaxyz/mainnet/refs/heads/m
 ssc_volume_size: "100Gi"
 ssc_rpc_servers:
   - https://ssc-statesync-us.sagarpc.io:443
-  - https://ssc-statesync-eu.sagarpc.io:443
+  - https://ssc-statesync-us.sagarpc.io:443
 ssc_peers: "f845f0325019ae4f060f3f26179b7902f75c92da@35.234.68.153:26656,3669aa25d9631619af40864ca6f67bac2efc7902@34.148.184.172:26656,ec1aa680c784f678a124a39be64205f6457b6964@34.64.142.18:26656"
 ssc_resources:
   requests:

--- a/ansible/roles/blockscout/templates/backend.yml.j2
+++ b/ansible/roles/blockscout/templates/backend.yml.j2
@@ -98,7 +98,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "10m"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "*"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,updated-gas-oracle"
 {% if cert_manager_enabled %}
     cert-manager.io/cluster-issuer: "{{ cert_manager_cluster_issuer_name }}"
 spec:

--- a/ansible/roles/controller/templates/chainlet/cosmos-exporter.yml.tmpl.j2
+++ b/ansible/roles/controller/templates/chainlet/cosmos-exporter.yml.tmpl.j2
@@ -33,7 +33,7 @@ spec:
               cpu: 10m
               memory: 80Mi
             limits:
-              cpu: 20m
+              cpu: 50m
               memory: 160Mi
           imagePullPolicy: IfNotPresent
           command:

--- a/ansible/roles/metrics/defaults/main.yml
+++ b/ansible/roles/metrics/defaults/main.yml
@@ -28,6 +28,7 @@ metrics_alertmanager_storage_size: 2Gi
 # AlertManager notification channels configuration
 # Set to false to disable AlertManager configuration (uses default config)
 metrics_alertmanager_config_enabled: false
+metrics_alertmanager_external_url: "http://kube-prometheus-stack-alertmanager.sagasrv-metrics:9093"
 
 # Global AlertManager settings
 metrics_alertmanager_global: {}

--- a/ansible/roles/metrics/templates/kube-prometheus-values.yml.j2
+++ b/ansible/roles/metrics/templates/kube-prometheus-values.yml.j2
@@ -53,8 +53,8 @@ prometheus:
 
 alertmanager:
   enabled: {{ metrics_alertmanager_enabled | bool | lower }}
-{% if metrics_alertmanager_storage_class or metrics_alertmanager_config_enabled %}
   alertmanagerSpec:
+    externalUrl: {{ metrics_alertmanager_external_url }}
 {% if metrics_alertmanager_storage_class %}
     storage:
       volumeClaimTemplate:
@@ -68,7 +68,6 @@ alertmanager:
 {% endif %}
 {% if metrics_alertmanager_config_enabled %}
     configSecret: alertmanager-config
-{% endif %}
 {% endif %}
 
 # Disable ServiceMonitors for components that don't expose metrics


### PR DESCRIPTION
A few changes
- Change ssc statesync url for mainnet
- Add `cors-allow-headers` to blockscout backend to prevent stat cors
- Increase cosmos-exporter limit